### PR TITLE
Correct code declaration in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,12 @@ Everyone farts. And now your web pages can too.
 1. Include "fartscroll.min.js" in your page.
 2. Initialize the fartscroll plugin on document.ready:
 
-    // Fart every 400 pixels scrolled in the document
-    $(document).fartscroll(); 
+```javascript
+// Fart every 400 pixels scrolled in the document
+$(document).fartscroll(); 
 
-    // Fart every 800 pixels scrolled in the document
-    $(document).fartscroll();
+// Fart every 800 pixels scrolled in the document
+$(document).fartscroll();
+```
     
 More info at [http://theonion.github.io/fartscroll.js/](http://theonion.github.io/fartscroll.js/).


### PR DESCRIPTION
The presence of a tab instead of 4 spaces was preventing markdown from recognizing a piece of code.
Additionally the use of three backticks allows the specification of the language.
