### PR TITLE
Ensure gh-page demos 'functionality'

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,6 +84,8 @@
     <script>
       $(document).ready(function() {
         $(document).fartscroll(400);
+        // Ensure scrolling, get in two farts
+        $('#container').css('height', window.innerHeight + 825);
       });
     </script>
   </body>


### PR DESCRIPTION
Make container height larger than browser window height to ensure 'functionality' is demonstrated.
