### PR TITLE
make the example continue on forever

### DIFF
--- a/example.html
+++ b/example.html
@@ -5,6 +5,13 @@
         <script src="fartscroll.js"></script>
         <script>
         $(document).ready(function() {
+            // Ensure the page always has more scrolling
+            $(document).scroll(function() {
+                while ((window.pageYOffset + window.innerHeight) >= $(this).height() - (window.innerHeight / 2)) {
+                    $('ul').append('<li>Testing.</li>');
+                }
+            }).scroll();
+
             $(document).fartscroll(800);
         });
         </script>


### PR DESCRIPTION
This way, even if the page is too large to scroll or the font is too small, it creates enough test items.
